### PR TITLE
Added option to allow other users to access mount

### DIFF
--- a/simple_httpfs/__main__.py
+++ b/simple_httpfs/__main__.py
@@ -48,7 +48,7 @@ def main():
         type=str)
     
     parser.add_argument(
-        '-o', '--allow-other',
+        '-a', '--allow-other',
         action='store_true',
         default=False,
         help='Allow other users to access this fuse')

--- a/simple_httpfs/__main__.py
+++ b/simple_httpfs/__main__.py
@@ -48,7 +48,7 @@ def main():
         type=str)
     
     parser.add_argument(
-        '-a', '--allow-other',
+        '--allow-other',
         action='store_true',
         default=False,
         help='Allow other users to access this fuse')

--- a/simple_httpfs/__main__.py
+++ b/simple_httpfs/__main__.py
@@ -46,6 +46,12 @@ def main():
         '--aws-profile',
         default=None,
         type=str)
+    
+    parser.add_argument(
+        '-o', '--allow-other',
+        action='store_true',
+        default=False,
+        help='Allow other users to access this fuse')
 
     parser.add_argument(
         '-l', '--log',
@@ -60,7 +66,7 @@ def main():
         sys.exit(1)
 
     logger = logging.getLogger('simple-httpfs')
-    logger.setLevel(logging.INFO)
+    logger.setLevel(logging.DEBUG)
 
     if args['log']:
         hdlr = logging.FileHandler(args['log'])
@@ -84,9 +90,11 @@ Mounting HTTP Filesystem...
     schema: {schema}
     mountpoint: {mountpoint}
     foreground: {foreground}
+    allow others: {allow_other}
 """.format(schema=schema,
            mountpoint=args['mountpoint'],
-           foreground=args['foreground'])
+           foreground=args['foreground'],
+           allow_other=args['allow_other'])
     print(start_msg, file=sys.stderr)
 
     fuse = FUSE(
@@ -100,7 +108,8 @@ Mounting HTTP Filesystem...
                logger = logger
             ),
         args['mountpoint'],
-        foreground=args['foreground']
+        foreground=args['foreground'],
+        allow_other=args['allow_other']
     )
 
 

--- a/simple_httpfs/__main__.py
+++ b/simple_httpfs/__main__.py
@@ -66,7 +66,7 @@ def main():
         sys.exit(1)
 
     logger = logging.getLogger('simple-httpfs')
-    logger.setLevel(logging.DEBUG)
+    logger.setLevel(logging.INFO)
 
     if args['log']:
         hdlr = logging.FileHandler(args['log'])


### PR DESCRIPTION
`-o` or `--allow-other` to enable the fuse's `allow_other` argument so you can have other users on the system to access the created fuse ~~for doing horrific things with QEMU and press the limits of what a web-server should reasonably do~~.