### PR TITLE
Add NumPy to setup.py requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,6 @@ setup(
     license="MIT",
     long_description=open("README.md").read(),
     long_description_content_type="text/markdown",
-    install_requires=["boto3", "diskcache", "fusepy", "requests", "slugid", "tenacity"],
+    install_requires=["boto3", "diskcache", "fusepy", "requests", "slugid", "tenacity", "numpy"],
     version="0.4.10",
 )


### PR DESCRIPTION
## Description

NumPy is a hard requirement in https://github.com/higlass/simple-httpfs/blob/4c8d4481aabb69bc6db5bc49ddf15cd2bab26eb4/simple_httpfs/httpfs.py#L3

But it isn't listed in the requirements. These changes ensure numpy is also installed when `pip install`-ing this lib into a fresh env

## Checklist

- [ ] Updated CHANGELOG.md