### PR TITLE
Change usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ the local filesystem.
 ## Usage
 
 ```
-simple-http /my/mount/dir
+python -m simple_httpfs /my/mount/dir
 curl /my/mount/dir/http/slashdot.org/country.js..
 ```
 


### PR DESCRIPTION
## Description

The usage instructions listed in the README do not work for me (Mac/Python3.7):

```bash
$ simple-http /my/mount/dir
zsh: command not found: simple-http
```

This PR changes those instructions to:
```bash
$ python -m simple_httpfs /my/mount/dir
```


## Checklist

- [ ] Updated CHANGELOG.md