### PR TITLE
Update httpfs.py

### DIFF
--- a/simple_httpfs/httpfs.py
+++ b/simple_httpfs/httpfs.py
@@ -137,7 +137,7 @@ class HttpFetcher:
 
     def get_size(self, url):
         try:
-            head = requests.head(url, allow_redirects=True, verify=self.SSL_VERIFY)
+            head = requests.head(url, headers={"Accept-Encoding": ""}, allow_redirects=True, verify=self.SSL_VERIFY)
             return int(head.headers["Content-Length"])
         except:
             head = requests.get(


### PR DESCRIPTION
bugfix: wrong file size when content-encoding is a compressed format (i.e. https://upload.wikimedia.org/wikipedia/commons/0/03/Flag_of_Italy.svg )

## Description

<!--- Description goes here --->

## Checklist

- [ ] Updated CHANGELOG.md